### PR TITLE
Fixed circular import error

### DIFF
--- a/medvae/__init__.py
+++ b/medvae/__init__.py
@@ -1,4 +1,4 @@
 from medvae.medvae_main import MVAE
-from medvae import losses
+from medvae.losses import *
 
 __all__ = ["MVAE", "losses"]


### PR DESCRIPTION
## The Error
(Closes #9)
I had a circular import error when importing MVAE. The code
```
import torch
from medvae import MVAE
```
throws the error
```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[2], line 2
      1 import torch
----> 2 from medvae import MVAE

File ~/miniconda3/envs/medvae-env/lib/python3.10/site-packages/medvae/__init__.py:2
      1 from medvae.medvae_main import MVAE
----> 2 from medvae import losses
      4 __all__ = ["MVAE", "losses"]

ImportError: cannot import name 'losses' from partially initialized module 'medvae' (most likely due to a circular import) (/home/hasith/miniconda3/envs/medvae-env/lib/python3.10/site-packages/medvae/__init__.py)
```

## Solution
This was solved with simply editing the `__init__.py` file to have
```
from medvae.losses import *
```
