### PR TITLE
Updated package dependencies

### DIFF
--- a/documentation/finetune.md
+++ b/documentation/finetune.md
@@ -102,6 +102,8 @@ To log training runs with wandb, ensure your wandb API key is set up. Enable log
 CUDA_VISIBLE_DEVICES=0 medvae_finetune experiment=medvae_4x_1c_2d_finetuning logger=wandb
 ```
 
+Note: We recommend using `wandb` version `0.14.0`. We have noticed logging errors with other versions with our setup.
+
 ## Inference Post-Finetuning
 
 Use our built-in inference engine to perform inference on your finetuned models:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "medvae"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.9"
 description = "MedVAE is a family of six medical image autoencoders that can encode high-dimensional medical images into latent representations."
 readme = "README.md"
@@ -36,7 +36,8 @@ keywords = [
 dependencies = [
     "torch>=2.4.1", # tested using 2.6.0
     "accelerate>=0.34.2", # tested using 0.34.2
-    "wandb==0.14.0",
+    "wandb==0.14.0; python_version < '3.12'",  # tested using 0.14.0 for older python
+    "wandb>=0.16.0; python_version >= '3.12'", # use newer wandb for Python 3.12
     "tqdm", # tested using 4.67.1
     "dicom2nifti", # tested using 2.5.1
     "scipy", # tested using 1.13.1


### PR DESCRIPTION
- Flexible wandb version installation to allow for more python versions to install medvae
- Added note in finetuning regarding this
- Tested on python versions 3.9-3.13