### PR TITLE
Removed git clip package (the code only uses open_clip)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ dependencies = [
     "open_clip_torch==2.24.0",
     "polars>=0.19.10", # tested using 0.19.10
     "rich", # tested using 13.9.4
-    "clip@git+https://github.com/openai/CLIP.git" # tested using 1.0
 ]
 
 [project.urls]


### PR DESCRIPTION
I had issues with setting up the codebase because of the git clip package. However, checking the codebase, only open_clip is used.

This PR aims to remove this dependency.